### PR TITLE
wi-sunモジュールでstartDiscovery時にException発生

### DIFF
--- a/lib/net/wisunb.js
+++ b/lib/net/wisunb.js
@@ -277,7 +277,7 @@ EchonetLiteNetWisunb.prototype.startDiscovery = function(buf, callback) {
 		callback = function() {};
 	}
 	this.is_discovering = true;
-	this._activeScan((err) => {
+	this._activeScan(buf, (err) => {
 		if(err) {
 			callback(err);
 		} else {
@@ -294,7 +294,7 @@ EchonetLiteNetWisunb.prototype.startDiscovery = function(buf, callback) {
 };
 
 // Start the active scan
-EchonetLiteNetWisunb.prototype._activeScan = function(callback) {
+EchonetLiteNetWisunb.prototype._activeScan = function(buf, callback) {
 	this._setSerialCallback((res) => {
 		if(res.match(/(^|\r\n)FAIL/)) {
 			var msg = 'Failed the active scan: ' + this._getFailLine(res);
@@ -317,7 +317,7 @@ EchonetLiteNetWisunb.prototype._activeScan = function(callback) {
 				}, this.SERIAL_SEND_INTERVAL);
 			} else {
 				this.discovery_timer_id = setTimeout(() => {
-					this.startDiscovery(callback);
+					this.startDiscovery(buf, callback);
 				}, this.SERIAL_SEND_INTERVAL);
 			}
 		}


### PR DESCRIPTION
状況: wi-sunモジュールを使用してSmrtMeterをstartDiscoveryで検索する時
_activeScanの中で”EVENT 22”を受けたときの処理でthis.SERIAL_SEND_INTERVALでstartDiscoveryを再度呼び出す処理があるが、startDiscoveryの第1引数が抜けているためExceptionが発生している。

対応：activeScanにbufを渡して、startDiscovery呼び出し時にbufを使用するように変更。

以下、発生したException
-----
[[ Exception ]]
Mon Jan 30 2017 22:03:22 GMT+0900 (JST)
TypeError: "list" argument must be an Array of Buffers
at Function.Buffer.concat (buffer.js:314:13)
at EchonetLiteNetWisunbAdapter.createBufferSKSENDTO (/home/test/wisun_test/node_modules/node-echonet-lite/lib/net/wisunb-bp35a1.js:29:23)
at EchonetLiteNetWisunb.send (/home/test/wisun_test/node_modules/node-echonet-lite/lib/net/wisunb.js:429:33)
at Timeout.setTimeout (/home/test/wisun_test/node_modules/node-echonet-lite/lib/net/wisunb.js:286:10)
at ontimeout (timers.js:365:14)
at tryOnTimeout (timers.js:237:5)
at Timer.listOnTimeout (timers.js:207:5)
TypeError: "list" argument must be an Array of Buffers
at Function.Buffer.concat (buffer.js:314:13)
at EchonetLiteNetWisunbAdapter.createBufferSKSENDTO (/home/test/wisun_test/node_modules/node-echonet-lite/lib/net/wisunb-bp35a1.js:29:23)
at EchonetLiteNetWisunb.send (/home/test/wisun_test/node_modules/node-echonet-lite/lib/net/wisunb.js:429:33)
at Timeout.setTimeout (/home/test/wisun_test/node_modules/node-echonet-lite/lib/net/wisunb.js:286:10)
at ontimeout (timers.js:365:14)
at tryOnTimeout (timers.js:237:5)
at Timer.listOnTimeout (timers.js:207:5)