### PR TITLE
Only listen once on each interface

### DIFF
--- a/lib/net/lan.js
+++ b/lib/net/lan.js
@@ -94,13 +94,15 @@ EchonetLiteNetLan.prototype._getNetIfList = function() {
 	let netifs = mOs.networkInterfaces();
 	let list = [];
 	for(let dev in netifs) {
-		netifs[dev].forEach((info) => {
+		netifs[dev].find((info) => {
 			if(info.family === 'IPv4' && info.internal === false) {
 				let m = info.address.match(/^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/);
 				if(m) {
 					list.push(m[1]);
+					return true;
 				}
 			}
+			return false;
 		});
 	}
 	return list;


### PR DESCRIPTION
I am running this in Docker on a Raspberry PI.

Upon start up, after connecting to MQTT, I get the following exception.

```
Error: addMembership EADDRINUSE
    at Socket.addMembership (dgram.js:629:11)
    at netif_list.forEach (/app/node_modules/node-echonet-lite/lib/net/lan.js:79:13)
    at Array.forEach (<anonymous>)
    at EchonetLiteNetLan._addMembership (/app/node_modules/node-echonet-lite/lib/net/lan.js:76:14)
    at Socket.udp.bind (/app/node_modules/node-echonet-lite/lib/net/lan.js:66:8)
    at Object.onceWrapper (events.js:273:13)
    at Socket.emit (events.js:182:13)
    at startListening (dgram.js:171:10)
    at _handle.lookup (dgram.js:289:7)
    at process._tickCallback (internal/process/next_tick.js:63:19)

```
Through debugging I found that the device has the following Interfaces and IP addresses:
```
Interface: lo,
	{"address":"127.0.0.1","netmask":"255.0.0.0","family":"IPv4","mac":"00:00:00:00:00:00","internal":true,"cidr":"127.0.0.1/8"}
	{"address":"::1","netmask":"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff","family":"IPv6","mac":"00:00:00:00:00:00","scopeid":0,"internal":true,"cidr":"::1/128"}
Interface: wlan0,
	{"address":"192.168.0.79","netmask":"255.255.255.0","family":"IPv4","mac":"b8:27:eb:80:e0:1e","internal":false,"cidr":"192.168.0.79/24"},
	{"address":"2406:e006:401a:1e01:43d9:8994:9d8a:2ce5","netmask":"ffff:ffff:ffff:ffff::","family":"IPv6","mac":"b8:27:eb:80:e0:1e","scopeid":0,"internal":false,"cidr":"2406:e006:401a:1e01:43d9:8994:9d8a:2ce5/64"},
	{"address":"fe80::3615:9e48:b4e9:9faf","netmask":"ffff:ffff:ffff:ffff::","family":"IPv6","mac":"b8:27:eb:80:e0:1e","scopeid":3,"internal":false,"cidr":"fe80::3615:9e48:b4e9:9faf/64"},
Interface: docker0,
	{"address":"172.17.0.1","netmask":"255.255.0.0","family":"IPv4","mac":"02:42:ef:5b:3e:ef","internal":false,"cidr":"172.17.0.1/16"},
	{"address":"169.254.250.38","netmask":"255.255.0.0","family":"IPv4","mac":"02:42:ef:5b:3e:ef","internal":false,"cidr":"169.254.250.38/16"},
	{"address":"fe80::af06:cf33:4cd4:7105","netmask":"ffff:ffff:ffff:ffff::","family":"IPv6","mac":"02:42:ef:5b:3e:ef","scopeid":6,"internal":false,"cidr":"fe80::af06:cf33:4cd4:7105/64"},
Interface: vethedc447d,
	{"address":"169.254.166.199","netmask":"255.255.0.0","family":"IPv4","mac":"de:2d:e1:43:0b:2b","internal":false,"cidr":"169.254.166.199/16"},
	{"address":"fe80::a32e:4689:c64e:b25e","netmask":"ffff:ffff:ffff:ffff::","family":"IPv6","mac":"de:2d:e1:43:0b:2b","scopeid":8,"internal":false,"cidr":"fe80::a32e:4689:c64e:b25e/64"},
Interface: vethf1fe4f1,
	{"address":"169.254.231.128","netmask":"255.255.0.0","family":"IPv4","mac":"16:77:72:b4:98:40","internal":false,"cidr":"169.254.231.128/16"},
	{"address":"fe80::1477:72ff:feb4:9840","netmask":"ffff:ffff:ffff:ffff::","family":"IPv6","mac":"16:77:72:b4:98:40","scopeid":137,"internal":false,"cidr":"fe80::1477:72ff:feb4:9840/64"},
```

I get the exception on the 2nd IP address on interface '`docker0`'. It looks like this is because the interface has 2 x IPv4 addresses that are not '`internal`'.
The exception is generated after listening on `172.17.0.1` and then attempting to listen on `169.254.250.38`.

This change returns only 1 x IPv4 address per interface instead of all IPv4 addresses.